### PR TITLE
Fix open sources licenses page being empty

### DIFF
--- a/src/assets/about/about.toml
+++ b/src/assets/about/about.toml
@@ -7,5 +7,11 @@ accepted = [
     "BSD-3-Clause",
     "BSL-1.0",
     "MPL-2.0",
-    "CC0-1.0"
+    "CC0-1.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+workarounds = [
+    "ring",
 ]


### PR DESCRIPTION
Added three missing licenses which were preventing the `cargo-about` from generating any output and apply a [workaround](https://embarkstudios.github.io/cargo-about/cli/generate/workarounds.html#ring) for `ring` crate.

This pull request closes #189.